### PR TITLE
Added dependency to searchAllPlayers useEffect and placeholder text in searchbar

### DIFF
--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -17,7 +17,7 @@ export default function SearchBar() {
   };
   return (
     <Form className="search-bar" onSubmit={handleSubmit}>
-      <FormControl type="text" size="sm" onChange={handleChange} value={searchInput} />
+      <FormControl type="text" placeholder="Search Players or Roles" size="sm" onChange={handleChange} value={searchInput} />
     </Form>
   );
 }

--- a/pages/search/[searchInput].js
+++ b/pages/search/[searchInput].js
@@ -19,6 +19,7 @@ export default function Search() {
     return () => {
       setFilteredPlayers([]);
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchInput]);
 
   return (

--- a/pages/search/[searchInput].js
+++ b/pages/search/[searchInput].js
@@ -19,7 +19,7 @@ export default function Search() {
     return () => {
       setFilteredPlayers([]);
     };
-  }, []);
+  }, [searchInput]);
 
   return (
     <>


### PR DESCRIPTION
## Description
Added searchInput dependency to searchAllPlayers useEffect so that the page refreshes after multiple search queries in a row and added placeholder text to searchbar.

## Related Issue
#19 

## Motivation and Context
Previously, if the user did more than one search in a row, the page wouldn't refresh for any search after the first, so the dependency was necessary. Also, the search bar didn't give any indication of what could be searched for prior to the placeholder text I added.

## How Can This Be Tested?
Can be tested by doing multiple searches back-to-back.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
